### PR TITLE
Add validation tests for Prisma schema and nudge service

### DIFF
--- a/app/server/.gitignore
+++ b/app/server/.gitignore
@@ -1,0 +1,2 @@
+# Prisma SQLite databases created during development and tests
+prisma/*.db*

--- a/app/server/prisma/schema.prisma
+++ b/app/server/prisma/schema.prisma
@@ -2,7 +2,7 @@
 
 datasource db {
   provider = "sqlite"
-  url      = "file:./data.db"
+  url      = env("DATABASE_URL")
 }
 
 generator client {

--- a/app/server/prisma/schema.prisma
+++ b/app/server/prisma/schema.prisma
@@ -10,14 +10,15 @@ generator client {
 }
 
 model Child {
-  id        String   @id @default(cuid())
+  id        String    @id @default(cuid())
   name      String
   birthdate DateTime?
-  active    Boolean  @default(true)
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  active    Boolean   @default(true)
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
 
-  sessions  Session[]
+  sessions Session[]
+  routines RoutineChild[]
 }
 
 model Task {
@@ -29,7 +30,7 @@ model Task {
   updatedAt           DateTime @updatedAt
 
   routineDefaults RoutineTaskDefault[]
-  sessionTasks   SessionTask[]
+  sessionTasks    SessionTask[]
 }
 
 model Routine {
@@ -47,7 +48,7 @@ model Routine {
 }
 
 model RoutineChild {
-  id        String  @id @default(cuid())
+  id        String @id @default(cuid())
   routineId String
   childId   String
 
@@ -58,7 +59,7 @@ model RoutineChild {
 }
 
 model RoutineTaskDefault {
-  id         String  @id @default(cuid())
+  id         String @id @default(cuid())
   routineId  String
   taskId     String
   orderIndex Int
@@ -71,7 +72,7 @@ model RoutineTaskDefault {
 }
 
 model Session {
-  id          String   @id @default(cuid())
+  id          String    @id @default(cuid())
   dateISO     String
   routineId   String
   childId     String
@@ -80,18 +81,18 @@ model Session {
   finishedAt  DateTime?
   windowStart String
   windowEnd   String
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
   reward      String?
 
-  routine Routine @relation(fields: [routineId], references: [id])
-  child   Child   @relation(fields: [childId], references: [id])
-  tasks   SessionTask[]
+  routine    Routine       @relation(fields: [routineId], references: [id])
+  child      Child         @relation(fields: [childId], references: [id])
+  tasks      SessionTask[]
   speechLogs SpeechLog[]
 }
 
 model SessionTask {
-  id          String   @id @default(cuid())
+  id          String    @id @default(cuid())
   sessionId   String
   taskId      String
   orderIndex  Int

--- a/app/server/src/app.ts
+++ b/app/server/src/app.ts
@@ -1,0 +1,68 @@
+import Fastify, { FastifyServerOptions } from 'fastify';
+import cors from '@fastify/cors';
+import swagger from '@fastify/swagger';
+import swaggerUi from '@fastify/swagger-ui';
+import rateLimit from '@fastify/rate-limit';
+import { ENV } from './env.js';
+import { logger } from './logger.js';
+import { adminRoutes } from './routes/admin.js';
+import { routinesRoutes } from './routes/routines.js';
+import { sessionsRoutes } from './routes/sessions.js';
+import { ttsRoutes } from './routes/tts.js';
+import { toHttpError } from './util/errors.js';
+
+type CreateServerOptions = FastifyServerOptions & {
+  disableRateLimit?: boolean;
+  disableDocs?: boolean;
+};
+
+export async function createServer(options: CreateServerOptions = {}) {
+  const { logger: overrideLogger, disableRateLimit, disableDocs, ...rest } = options;
+  const fastify = Fastify({
+    ...(rest as FastifyServerOptions),
+    logger: overrideLogger ?? logger,
+  });
+
+  await fastify.register(cors, {
+    origin: ENV.NODE_ENV === 'development' ? true : [/localhost/, /127\.0\.0\.1/],
+    methods: ['GET', 'POST', 'PUT', 'DELETE'],
+  });
+
+  if (!disableRateLimit) {
+    await fastify.register(rateLimit, {
+      max: ENV.RATE_LIMIT_POINTS,
+      timeWindow: `${ENV.RATE_LIMIT_DURATION} seconds`,
+      skipOnError: true,
+    });
+  }
+
+  if (!disableDocs) {
+    await fastify.register(swagger, {
+      openapi: {
+        info: {
+          title: 'KlarParat API',
+          version: '0.1.0',
+        },
+      },
+    });
+
+    await fastify.register(swaggerUi, {
+      routePrefix: '/docs',
+    });
+  }
+
+  await fastify.register(async (instance) => {
+    await instance.register(adminRoutes);
+    await instance.register(routinesRoutes);
+    await instance.register(sessionsRoutes);
+    await instance.register(ttsRoutes);
+  });
+
+  fastify.setErrorHandler((error, request, reply) => {
+    fastify.log.error({ err: error }, 'Unhandled error');
+    const mapped = toHttpError(error);
+    reply.status(mapped.status).send(mapped.body);
+  });
+
+  return fastify;
+}

--- a/app/server/src/env.ts
+++ b/app/server/src/env.ts
@@ -13,9 +13,14 @@ const envSchema = z.object({
   OPENAI_TTS_VOICE: z.string().default('alloy'),
   RATE_LIMIT_POINTS: z.string().default('30'),
   RATE_LIMIT_DURATION: z.string().default('60'),
+  DATABASE_URL: z.string().default('file:./prisma/data.db'),
 });
 
 const env = envSchema.parse(process.env);
+
+if (!process.env.DATABASE_URL) {
+  process.env.DATABASE_URL = env.DATABASE_URL;
+}
 
 export const ENV = {
   ...env,

--- a/app/server/src/index.ts
+++ b/app/server/src/index.ts
@@ -1,53 +1,7 @@
-import Fastify from 'fastify';
-import cors from '@fastify/cors';
-import swagger from '@fastify/swagger';
-import swaggerUi from '@fastify/swagger-ui';
-import rateLimit from '@fastify/rate-limit';
 import { ENV } from './env.js';
-import { logger } from './logger.js';
-import { adminRoutes } from './routes/admin.js';
-import { routinesRoutes } from './routes/routines.js';
-import { sessionsRoutes } from './routes/sessions.js';
-import { ttsRoutes } from './routes/tts.js';
-import { toHttpError } from './util/errors.js';
+import { createServer } from './app.js';
 
-const fastify = Fastify({ logger });
-
-await fastify.register(cors, {
-  origin: ENV.NODE_ENV === 'development' ? true : [/localhost/, /127\.0\.0\.1/],
-  methods: ['GET', 'POST', 'PUT', 'DELETE'],
-});
-
-await fastify.register(rateLimit, {
-  max: ENV.RATE_LIMIT_POINTS,
-  timeWindow: `${ENV.RATE_LIMIT_DURATION} seconds`,
-  skipOnError: true,
-});
-
-await fastify.register(swagger, {
-  openapi: {
-    info: {
-      title: 'KlarParat API',
-      version: '0.1.0',
-    },
-  },
-});
-await fastify.register(swaggerUi, {
-  routePrefix: '/docs',
-});
-
-await fastify.register(async (instance) => {
-  await instance.register(adminRoutes);
-  await instance.register(routinesRoutes);
-  await instance.register(sessionsRoutes);
-  await instance.register(ttsRoutes);
-});
-
-fastify.setErrorHandler((error, request, reply) => {
-  logger.error({ err: error }, 'Unhandled error');
-  const mapped = toHttpError(error);
-  reply.status(mapped.status).send(mapped.body);
-});
+const fastify = await createServer();
 
 fastify.listen({ port: ENV.PORT, host: '0.0.0.0' }).catch((err) => {
   fastify.log.error(err);

--- a/app/server/src/prisma.ts
+++ b/app/server/src/prisma.ts
@@ -1,3 +1,13 @@
 import { PrismaClient } from '@prisma/client';
 
-export const prisma = new PrismaClient();
+const databaseUrl = process.env.DATABASE_URL;
+
+export const prisma = new PrismaClient({
+  datasources: databaseUrl
+    ? {
+        db: {
+          url: databaseUrl,
+        },
+      }
+    : undefined,
+});

--- a/app/server/src/prisma/schema-validation.test.ts
+++ b/app/server/src/prisma/schema-validation.test.ts
@@ -7,6 +7,8 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const projectRoot = path.resolve(__dirname, '..', '..');
 
+process.env.DATABASE_URL ??= 'file:./prisma/data.db';
+
 describe('Prisma schema', () => {
   it('passes `prisma validate`', () => {
     let output: Buffer | string = Buffer.from('');

--- a/app/server/src/prisma/schema-validation.test.ts
+++ b/app/server/src/prisma/schema-validation.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '..', '..');
+
+describe('Prisma schema', () => {
+  it('passes `prisma validate`', () => {
+    let output: Buffer | string = Buffer.from('');
+    expect(() => {
+      output = execSync('npx prisma validate', {
+        cwd: projectRoot,
+        stdio: 'pipe',
+      });
+    }).not.toThrow();
+
+    const textOutput = output.toString();
+    expect(textOutput).toContain('Prisma schema loaded');
+    expect(textOutput).toContain('is valid');
+  });
+});

--- a/app/server/src/routes/admin.integration.test.ts
+++ b/app/server/src/routes/admin.integration.test.ts
@@ -1,0 +1,179 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import fs from 'node:fs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '..', '..');
+
+const databaseName = `test-admin-${process.pid}-${Date.now()}.db`;
+const databaseUrl = `file:./${databaseName}`;
+const sqlitePath = path.resolve(projectRoot, 'prisma', databaseName);
+
+process.env.NODE_ENV = 'test';
+process.env.DATABASE_URL = databaseUrl;
+process.env.ADMIN_PIN = '1234';
+process.env.OPENAI_API_KEY = 'test-api-key';
+process.env.OPENAI_TEXT_MODEL = 'gpt-test';
+process.env.OPENAI_TTS_MODEL = 'gpt-tts';
+process.env.OPENAI_TTS_VOICE = 'test';
+process.env.RATE_LIMIT_POINTS = '100';
+process.env.RATE_LIMIT_DURATION = '60';
+
+const estimateMock = vi.fn(async ({ tasks }: { tasks: Array<{ id: string }> }) => ({
+  estimates: tasks.map((task, index) => ({
+    taskId: task.id,
+    estimatedSeconds: 90 + index * 15,
+  })),
+  notes: null,
+}));
+
+vi.mock('../services/llmEstimate.js', () => ({
+  estimateDurations: estimateMock,
+}));
+
+const { prisma } = await import('../prisma.js');
+const { createServer } = await import('../app.js');
+
+describe('admin and routines routes with sqlite database', () => {
+  const adminHeaders = { 'x-admin-pin': '1234' };
+  let server: Awaited<ReturnType<typeof createServer>> | null = null;
+
+  beforeAll(async () => {
+    execSync('npx prisma db push --force-reset --skip-generate', {
+      cwd: projectRoot,
+      env: { ...process.env, DATABASE_URL: databaseUrl },
+      stdio: 'pipe',
+    });
+    server = await createServer({ logger: false, disableRateLimit: true, disableDocs: true });
+    await server.ready();
+  });
+
+  beforeEach(async () => {
+    await prisma.$transaction([
+      prisma.speechLog.deleteMany(),
+      prisma.sessionTask.deleteMany(),
+      prisma.session.deleteMany(),
+      prisma.routineTaskDefault.deleteMany(),
+      prisma.routineChild.deleteMany(),
+      prisma.routine.deleteMany(),
+      prisma.task.deleteMany(),
+      prisma.child.deleteMany(),
+    ]);
+    estimateMock.mockClear();
+  });
+
+  afterAll(async () => {
+    if (server) {
+      await server.close();
+    }
+    await prisma.$disconnect();
+    for (const suffix of ['', '-journal', '-wal', '-shm']) {
+      try {
+        fs.rmSync(`${sqlitePath}${suffix}`, { force: true });
+      } catch {
+        // ignore cleanup failures
+      }
+    }
+  });
+
+  it('creates routines with related defaults and children through the admin API', async () => {
+    if (!server) {
+      throw new Error('Server not initialised');
+    }
+    const childResponse = await server.inject({
+      method: 'POST',
+      url: '/api/admin/children',
+      headers: adminHeaders,
+      payload: { name: 'Alma', active: true },
+    });
+    expect(childResponse.statusCode).toBe(201);
+    const child = childResponse.json();
+
+    const firstTaskResponse = await server.inject({
+      method: 'POST',
+      url: '/api/admin/tasks',
+      headers: adminHeaders,
+      payload: { title: 'Brush teeth' },
+    });
+    const secondTaskResponse = await server.inject({
+      method: 'POST',
+      url: '/api/admin/tasks',
+      headers: adminHeaders,
+      payload: { title: 'Eat breakfast' },
+    });
+    expect(firstTaskResponse.statusCode).toBe(201);
+    expect(secondTaskResponse.statusCode).toBe(201);
+    const taskA = firstTaskResponse.json();
+    const taskB = secondTaskResponse.json();
+
+    const routineResponse = await server.inject({
+      method: 'POST',
+      url: '/api/admin/routines',
+      headers: adminHeaders,
+      payload: {
+        title: 'Morning',
+        startTime: '07:00',
+        endTime: '07:30',
+        childIds: [child.id],
+        taskOrder: [
+          { taskId: taskA.id, orderIndex: 0 },
+          { taskId: taskB.id, orderIndex: 1 },
+        ],
+        active: true,
+      },
+    });
+
+    expect(routineResponse.statusCode).toBe(201);
+    expect(estimateMock).toHaveBeenCalledOnce();
+
+    const payload = routineResponse.json();
+    expect(payload.defaults).toHaveLength(2);
+    expect(payload.defaults[0].estSeconds).toBe(90);
+    expect(payload.defaults[1].estSeconds).toBe(105);
+
+    const savedRoutine = await prisma.routine.findUnique({
+      where: { id: payload.routine.id },
+      include: {
+        defaults: { orderBy: { orderIndex: 'asc' } },
+        children: true,
+      },
+    });
+    expect(savedRoutine).not.toBeNull();
+    expect(savedRoutine?.children).toHaveLength(1);
+    expect(savedRoutine?.children[0]?.childId).toBe(child.id);
+    expect(savedRoutine?.defaults.map((d) => d.estSeconds)).toEqual([90, 105]);
+  });
+
+  it('returns active routines with relational children and tasks', async () => {
+    if (!server) {
+      throw new Error('Server not initialised');
+    }
+    const child = await prisma.child.create({ data: { name: 'Otto' } });
+    const routine = await prisma.routine.create({
+      data: { title: 'Evening', startTime: '19:00', endTime: '19:45', active: true },
+    });
+    const task = await prisma.task.create({ data: { title: 'Read book' } });
+    await prisma.routineChild.create({ data: { routineId: routine.id, childId: child.id } });
+    await prisma.routineTaskDefault.create({
+      data: {
+        routineId: routine.id,
+        taskId: task.id,
+        orderIndex: 0,
+        estSeconds: 180,
+      },
+    });
+
+    const response = await server.inject({ method: 'GET', url: '/api/routines' });
+    expect(response.statusCode).toBe(200);
+    const routines = response.json();
+    expect(routines).toHaveLength(1);
+    expect(routines[0]).toMatchObject({
+      title: 'Evening',
+      children: [{ id: child.id, name: 'Otto' }],
+      tasks: [{ taskId: task.id, estSeconds: 180, orderIndex: 0 }],
+    });
+  });
+});

--- a/app/server/src/services/nudge.test.ts
+++ b/app/server/src/services/nudge.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { computeIdleThreshold, shouldNudge } from './nudge.js';
+
+describe('computeIdleThreshold', () => {
+  it('does not drop below the minimum idle threshold', () => {
+    expect(computeIdleThreshold(10)).toBe(30);
+  });
+
+  it('scales with the planned seconds when above the minimum', () => {
+    expect(computeIdleThreshold(200)).toBe(150);
+  });
+});
+
+describe('shouldNudge', () => {
+  const baseTime = new Date('2024-01-01T00:00:00Z');
+
+  it('returns false when the task has not started', () => {
+    expect(
+      shouldNudge(null, null, 120, baseTime)
+    ).toBe(false);
+  });
+
+  it('returns false when the task was already completed', () => {
+    const startedAt = new Date(baseTime.getTime() - 120_000);
+    const completedAt = new Date(baseTime.getTime() - 60_000);
+    expect(
+      shouldNudge(completedAt, startedAt, 120, baseTime)
+    ).toBe(false);
+  });
+
+  it('returns false when within the idle threshold', () => {
+    const startedAt = new Date(baseTime.getTime() - 60_000);
+    expect(
+      shouldNudge(null, startedAt, 200, baseTime)
+    ).toBe(false);
+  });
+
+  it('returns false when nudged less than a minute ago', () => {
+    const startedAt = new Date(baseTime.getTime() - 200_000);
+    const lastNudgedAt = new Date(baseTime.getTime() - 30_000);
+    expect(
+      shouldNudge(null, startedAt, 120, baseTime, lastNudgedAt)
+    ).toBe(false);
+  });
+
+  it('returns true when idle past the threshold without a recent nudge', () => {
+    const startedAt = new Date(baseTime.getTime() - 200_000);
+    expect(
+      shouldNudge(null, startedAt, 120, baseTime)
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add the missing Child relation to RoutineChild in the Prisma schema
- add Vitest coverage for the nudge service behaviour and Prisma schema validation

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e610c1d168832d8ba528c9d607671b